### PR TITLE
New exporters and small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # prometheus_exporters
 
+## 0.7.0
+
+- [Kieren Scott] - Add mysqld_exporter
+- [Matt Mencel] - Add wmi_exporter
+- [Viktor Radnai] - Add 'enabled' attribute for using with Chef search
+- [Viktor Radnai] - Fix: Remove unnecessary install step from redis exporter start action
+- [Viktor Radnai] - Fix: quote environment variable values in init script
+
+
+commit ae7991ca2aec19e7cbaadbef40728d5c28bcc23e
+Author: Viktor Radnai <viktor.radnai@ticketmaster.co.uk>
+Date:   Wed Nov 15 17:58:09 2017 +0000
+
 ## 0.6.1
 
 - [Kirill Kuznetsov] - fixed #7

--- a/README.md
+++ b/README.md
@@ -128,6 +128,25 @@ snmp_exporter 'main' do
 end
 ```
 
+## wmi_exporter
+
+Depends on the Chocolatey package manager.
+
+* `version`, String, default: '0.2.7'
+* `enabled_collectors`, String, default: 'cpu,cs,logical_disk,net,os,service,system'
+* `listen_address`, String, default: '0.0.0.0'
+* `listen_port`, String, default: '9182'
+* `metrics_path`, Strin, default: '/metrics'
+
+Use the given defaults or set the attributes...
+
+* `node['prometheus_exporters']['wmi']['version']['listen_interface']`
+* `node['prometheus_exporters']['wmi']['listen_address']`
+* `node['prometheus_exporters']['wmi']['listen_port']`
+* `node['prometheus_exporters']['wmi']['metrics_path']`
+
+and add `recipe['prometheus_exporters::wmi]` to your run_list.
+
 # Known Issues
 
 * The snmp_exporter requires a configuration file that is usually created by a config generator. Currently this functionality must be provided by a wrapper cookbook.

--- a/attributes/blackbox.rb
+++ b/attributes/blackbox.rb
@@ -1,0 +1,5 @@
+default['prometheus_exporters']['blackbox']['version'] = '0.12.0'
+default['prometheus_exporters']['blackbox']['url'] = "https://github.com/prometheus/blackbox_exporter/releases/download/v#{node['prometheus_exporters']['blackbox']['version']}/blackbox_exporter-#{node['prometheus_exporters']['blackbox']['version']}.linux-amd64.tar.gz"
+default['prometheus_exporters']['blackbox']['checksum'] = 'c5d8ba7d91101524fa7c3f5e17256d467d44d5e1d243e251fd795e0ab4a83605'
+default['prometheus_exporters']['blackbox']['timeout_offset'] = '0.5'
+default['prometheus_exporters']['blackbox']['log_level'] = 'info'

--- a/attributes/mysqld.rb
+++ b/attributes/mysqld.rb
@@ -1,0 +1,3 @@
+default['prometheus_exporters']['mysqld']['version'] = '0.10.0'
+default['prometheus_exporters']['mysqld']['url'] = "https://github.com/prometheus/mysqld_exporter/releases/download/v#{node['prometheus_exporters']['mysqld']['version']}/mysqld_exporter-#{node['prometheus_exporters']['mysqld']['version']}.linux-amd64.tar.gz"
+default['prometheus_exporters']['mysqld']['checksum'] = '32797bc96aa00bb20e0b9165f6d3887fe9612b474061ee7de0189f5377b61859'

--- a/attributes/redis.rb
+++ b/attributes/redis.rb
@@ -1,2 +1,3 @@
-default['prometheus_exporters']['redis']['url'] = 'https://github.com/oliver006/redis_exporter/releases/download/v0.18.0/redis_exporter-v0.18.0.linux-amd64.tar.gz'
+default['prometheus_exporters']['redis']['version'] = '0.18.0'
+default['prometheus_exporters']['redis']['url'] = "https://github.com/oliver006/redis_exporter/releases/download/v#{node['prometheus_exporters']['redis']['version']}/redis_exporter-v#{node['prometheus_exporters']['redis']['version']}.linux-amd64.tar.gz"
 default['prometheus_exporters']['redis']['checksum'] = '394aea00be7dc84682edc6d06128db68db43ab79ca1f5feacd8c42ed79d83246'

--- a/attributes/wmi.rb
+++ b/attributes/wmi.rb
@@ -1,0 +1,15 @@
+default['prometheus_exporters']['wmi']['version'] = '0.2.7'
+
+default['prometheus_exporters']['wmi']['enabled_collectors'] = %w[
+  cpu
+  cs
+  logical_disk
+  net
+  os
+  service
+  system
+]
+
+default['prometheus_exporters']['wmi']['listen_address'] = '0.0.0.0'
+default['prometheus_exporters']['wmi']['listen_port'] = '9182'
+default['prometheus_exporters']['wmi']['metrics_path'] = '/metrics'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'surrender@evilmartians.com'
 license          'Apache-2.0'
 description      'Installs / configures Prometheus exporters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.1'
+version          '0.7.0'
 
-chef_version '>= 12.19', '< 15.0'
+chef_version '>= 12.14', '< 15.0'
 
 supports 'centos', '>= 6.9'
 supports 'debian', '>= 8.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'surrender@evilmartians.com'
 license          'Apache-2.0'
 description      'Installs / configures Prometheus exporters'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.0'
+version          '0.8.0'
 
 chef_version '>= 12.14', '< 15.0'
 

--- a/recipes/blackbox.rb
+++ b/recipes/blackbox.rb
@@ -1,0 +1,11 @@
+unless node['prometheus_exporters']['disable']
+
+  blackbox_exporter 'main' do
+    web_listen_address "0.0.0.0:9115"
+    config_file "/opt/blackbox_exporter-#{node['prometheus_exporters']['blackbox']['version']}.linux-amd64/blackbox.yml"
+    timeout_offset node['prometheus_exporters']['blackbox']['timeout_offset']
+    log_level node['prometheus_exporters']['blackbox']['log_level']
+
+    action %i[install enable start]
+  end
+end

--- a/recipes/wmi.rb
+++ b/recipes/wmi.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: prometheus_exporters
+# Recipe:: wmi
+#
+# The wmi recipe makes use of the Chef chocolatey_package resource.  This will perform a default install of the Chocolatey package management system if it doesn't already exist.
+
+wmi_exporter 'main' do
+  version node['prometheus_exporters']['wmi']['version']
+  enabled_collectors node['prometheus_exporters']['wmi']['enabled_collectors'].join(',')
+  listen_address node['prometheus_exporters']['wmi']['listen_address']
+  listen_port node['prometheus_exporters']['wmi']['listen_port']
+  metrics_path node['prometheus_exporters']['wmi']['metrics_path']
+  action :install
+  not_if { node['prometheus_exporters']['disable'] }
+end

--- a/resources/blackbox.rb
+++ b/resources/blackbox.rb
@@ -14,6 +14,7 @@ action :install do
   options += " --timeout-offset #{new_resource.timeout_offset}"
   options += " --log.level #{new_resource.log_level}"
 
+  prometheus_user = new_resource.respond_to?(:user) ? new_resource.user : 'root'
 
   # Download binary
   remote_file 'blackbox_exporter' do
@@ -56,7 +57,7 @@ action :install do
     end
 
     directory "/var/log/prometheus/#{service_name}" do
-      owner new_resource.user
+      owner prometheus_user
       group 'root'
       mode '0755'
       action :create
@@ -70,7 +71,7 @@ action :install do
       mode '0755'
       variables(
         name: service_name,
-        user: new_resource.user,
+        user: prometheus_user,
         cmd: "/usr/local/sbin/blackbox_exporter #{options}",
         service_description: 'Prometheus Blackbox Exporter',
       )
@@ -107,7 +108,7 @@ action :install do
       mode '0644'
       variables(
         env: environment_list,
-        user: new_resource.user,
+        user: prometheus_user,
         cmd: "/usr/local/sbin/blackbox_exporter #{options}",
         service_description: 'Prometheus Blackbox Exporter',
       )

--- a/resources/blackbox.rb
+++ b/resources/blackbox.rb
@@ -1,0 +1,145 @@
+resource_name :blackbox_exporter
+
+property :web_listen_address, String, default: '0.0.0.0:9115'
+property :config_file, String, required: true
+property :timeout_offset, String, default: '0.5'
+property :log_level, String, default: 'info'
+
+action :install do
+  service_name = "blackbox_exporter_#{new_resource.name}"
+  node.default['prometheus_exporters']['blackbox']['enabled'] = true
+
+  options = "--web.listen-address #{new_resource.web_listen_address}"
+  options += " --config.file #{new_resource.config_file}"
+  options += " --timeout-offset #{new_resource.timeout_offset}"
+  options += " --log.level #{new_resource.log_level}"
+
+
+  # Download binary
+  remote_file 'blackbox_exporter' do
+    path "#{Chef::Config[:file_cache_path]}/blackbox_exporter.tar.gz"
+    owner 'root'
+    group 'root'
+    mode '0644'
+    source node['prometheus_exporters']['blackbox']['url']
+    checksum node['prometheus_exporters']['blackbox']['checksum']
+    notifies :restart, "service[#{service_name}]"
+  end
+
+  bash 'untar blackbox_exporter' do
+    code "tar -xzf #{Chef::Config[:file_cache_path]}/blackbox_exporter.tar.gz -C /opt"
+    action :nothing
+    subscribes :run, 'remote_file[blackbox_exporter]', :immediately
+  end
+
+  link '/usr/local/sbin/blackbox_exporter' do
+    to "/opt/blackbox_exporter-#{node['prometheus_exporters']['blackbox']['version']}.linux-amd64/blackbox_exporter"
+  end
+
+  service service_name do
+    action :nothing
+  end
+
+  case node['init_package']
+  when /init/
+    %w[
+      /var/run/prometheus
+      /var/log/prometheus
+    ].each do |dir|
+      directory dir do
+        owner 'root'
+        group 'root'
+        mode '0755'
+        recursive true
+        action :create
+      end
+    end
+
+    directory "/var/log/prometheus/#{service_name}" do
+      owner new_resource.user
+      group 'root'
+      mode '0755'
+      action :create
+    end
+
+    template "/etc/init.d/#{service_name}" do
+      cookbook 'prometheus_exporters'
+      source 'initscript.erb'
+      owner 'root'
+      group 'root'
+      mode '0755'
+      variables(
+        name: service_name,
+        user: new_resource.user,
+        cmd: "/usr/local/sbin/blackbox_exporter #{options}",
+        service_description: 'Prometheus Blackbox Exporter',
+      )
+      notifies :restart, "service[#{service_name}]"
+    end
+  when /systemd/
+    systemd_unit "#{service_name}.service" do
+      content(
+        'Unit' => {
+          'Description' => 'Systemd unit for Prometheus Blackbox Exporter',
+          'After' => 'network.target remote-fs.target apiserver.service',
+        },
+        'Service' => {
+          'Type' => 'simple',
+          'User' => 'root',
+          'ExecStart' => "/usr/local/sbin/blackbox_exporter #{options}",
+          'WorkingDirectory' => '/',
+          'Restart' => 'on-failure',
+          'RestartSec' => '30s',
+        },
+        'Install' => {
+          'WantedBy' => 'multi-user.target',
+        },
+      )
+      notifies :restart, "service[#{service_name}]"
+      action :create
+    end
+  when /upstart/
+    template "/etc/init/#{service_name}.conf" do
+      cookbook 'prometheus_exporters'
+      source 'upstart.conf.erb'
+      owner 'root'
+      group 'root'
+      mode '0644'
+      variables(
+        env: environment_list,
+        user: new_resource.user,
+        cmd: "/usr/local/sbin/blackbox_exporter #{options}",
+        service_description: 'Prometheus Blackbox Exporter',
+      )
+      notifies :restart, "service[#{service_name}]"
+    end
+
+  else
+    raise "Init system '#{node['init_package']}' is not supported by the 'prometheus_exporters' cookbook"
+  end
+end
+
+action :enable do
+  action_install
+  service "blackbox_exporter_#{new_resource.name}" do
+    action :enable
+  end
+end
+
+action :start do
+  service "blackbox_exporter_#{new_resource.name}" do
+    action :start
+  end
+end
+
+action :disable do
+  service "blackbox_exporter_#{new_resource.name}" do
+    action :disable
+  end
+end
+
+action :stop do
+  service "blackbox_exporter_#{new_resource.name}" do
+    action :stop
+  end
+end

--- a/resources/mysqld.rb
+++ b/resources/mysqld.rb
@@ -1,0 +1,181 @@
+#
+# Cookbook Name:: prometheus_exporters
+# Resource:: mysqld
+#
+# Copyright 2017, Evil Martians
+#
+# All rights reserved - Do Not Redistribute
+#
+
+resource_name :mysqld_exporter
+
+property :instance_name, String, name_property: true
+property :data_source_name, String, required: true
+property :log_format, String, default: 'logger:stdout?json=false'
+property :log_level, String
+property :web_listen_address, String, default: '0.0.0.0:9104'
+property :web_telemetry_path, String
+property :config_my_cnf, String, default: '~/.my.cnf'
+property :user, String, default: 'mysql'
+property :collector_flags, String, default: '\
+-collect.global_status \
+-collect.engine_innodb_status \
+-collect.global_variables \
+-collect.info_schema.clientstats \
+-collect.info_schema.innodb_metrics \
+-collect.info_schema.processlist \
+-collect.info_schema.tables.databases \
+-collect.info_schema.tablestats \
+-collect.slave_status \
+-collect.binlog_size \
+-collect.perf_schema.tableiowaits \
+-collect.perf_schema.indexiowaits \
+-collect.perf_schema.tablelocks'
+
+action :install do
+  # Set property that can be queried with Chef search
+  node.default['prometheus_exporters']['mysqld']['enabled'] = true
+
+  service_name = "mysqld_exporter_#{new_resource.instance_name}"
+
+  options = "-web.listen-address '#{new_resource.web_listen_address}'"
+  options += " -web.telemetry-path '#{new_resource.web_telemetry_path}'" if new_resource.web_telemetry_path
+  options += " -config.my-cnf '#{new_resource.config_my_cnf}'" if new_resource.config_my_cnf
+  options += " -log.level #{new_resource.log_level}" if new_resource.log_level
+  options += " -log.format '#{new_resource.log_format}'"
+  options += " #{new_resource.collector_flags}" if new_resource.collector_flags
+
+  env = {
+    'DATA_SOURCE_NAME' => new_resource.data_source_name,
+  }
+
+  remote_file 'mysqld_exporter' do
+    path "#{Chef::Config[:file_cache_path]}/mysqld_exporter.tar.gz"
+    owner 'root'
+    group 'root'
+    mode '0644'
+    source node['prometheus_exporters']['mysqld']['url']
+    checksum node['prometheus_exporters']['mysqld']['checksum']
+  end
+
+  bash 'untar mysqld_exporter' do
+    code "tar -xzf #{Chef::Config[:file_cache_path]}/mysqld_exporter.tar.gz -C /opt"
+    action :nothing
+    subscribes :run, 'remote_file[mysqld_exporter]', :immediately
+  end
+
+  link '/usr/local/sbin/mysqld_exporter' do
+    to "/opt/mysqld_exporter-#{node['prometheus_exporters']['mysqld']['version']}.linux-amd64/mysqld_exporter"
+  end
+
+  service service_name do
+    action :nothing
+  end
+
+  case node['init_package']
+  when /init/
+    %w[
+      /var/run/prometheus
+      /var/log/prometheus
+    ].each do |dir|
+      directory dir do
+        owner 'root'
+        group 'root'
+        mode '0755'
+        recursive true
+        action :create
+      end
+    end
+
+    directory "/var/log/prometheus/#{service_name}" do
+      owner new_resource.user
+      group 'root'
+      mode '0755'
+      action :create
+    end
+
+    template "/etc/init.d/#{service_name}" do
+      cookbook 'prometheus_exporters'
+      source 'initscript.erb'
+      owner 'root'
+      group 'root'
+      mode '0755'
+      variables(
+        env: env,
+        user: new_resource.user,
+        name: service_name,
+        cmd: "/usr/local/sbin/mysqld_exporter #{options}",
+        service_description: 'Prometheus MySQL Exporter',
+      )
+      notifies :restart, "service[#{service_name}]"
+    end
+
+  when /systemd/
+    systemd_unit "#{service_name}.service" do
+      content(
+        'Unit' => {
+          'Description' => 'Systemd unit for Prometheus MySQL Exporter',
+          'After' => 'network.target remote-fs.target apiserver.service',
+        },
+        'Service' => {
+          'Type' => 'simple',
+          'User' => new_resource.user,
+          'ExecStart' => "/usr/local/sbin/mysqld_exporter #{options}",
+          'Environment' => env.map { |k, v| "'#{k}=#{v}'" }.join(' '),
+          'WorkingDirectory' => '/',
+          'Restart' => 'on-failure',
+          'RestartSec' => '30s',
+        },
+        'Install' => {
+          'WantedBy' => 'multi-user.target',
+        },
+      )
+      notifies :restart, "service[#{service_name}]"
+      action :create
+    end
+
+  when /upstart/
+    template "/etc/init/#{service_name}.conf" do
+      cookbook 'prometheus_exporters'
+      source 'upstart.conf.erb'
+      owner 'root'
+      group 'root'
+      mode '0644'
+      variables(
+        env: env,
+        setuid: new_resource.user,
+        cmd: "/usr/local/sbin/mysqld_exporter #{options}",
+        service_description: 'Prometheus MySQL Exporter',
+      )
+      notifies :restart, "service[#{service_name}]"
+    end
+
+  else
+    raise "Init system '#{node['init_package']}' is not supported by the 'prometheus_exporters' cookbook"
+  end
+end
+
+action :enable do
+  action_install
+  service "mysqld_exporter_#{new_resource.instance_name}" do
+    action :enable
+  end
+end
+
+action :start do
+  service "mysqld_exporter_#{new_resource.instance_name}" do
+    action :start
+  end
+end
+
+action :disable do
+  service "mysqld_exporter_#{new_resource.instance_name}" do
+    action :disable
+  end
+end
+
+action :stop do
+  service "mysqld_exporter_#{new_resource.instance_name}" do
+    action :stop
+  end
+end

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -87,6 +87,9 @@ property :collector_filesystem_ignored_mount_points, String
 property :custom_options, String
 
 action :install do
+  # Set property that can be queried with Chef search
+  node.default['prometheus_exporters']['node']['enabled'] = true
+
   options = "--web.listen-address=#{new_resource.web_listen_address}"
   options += " --web.telemetry-path=#{new_resource.web_telemetry_path}"
   options += " --log.level=#{new_resource.log_level}"

--- a/resources/postgres.rb
+++ b/resources/postgres.rb
@@ -53,9 +53,7 @@ action :install do
   end
 
   link '/usr/local/sbin/postgres_exporter' do
-    to "/opt/node_exporter-#{node['prometheus_exporters']['node']['version']}.linux-amd64/node_exporter"
     to "/opt/postgres_exporter_#{node['prometheus_exporters']['postgres']['version']}_linux-amd64/postgres_exporter"
-    notifies :restart, "service[#{service_name}]"
   end
 
   service service_name do

--- a/resources/postgres.rb
+++ b/resources/postgres.rb
@@ -20,6 +20,9 @@ property :web_telemetry_path, String
 property :user, String, default: 'postgres'
 
 action :install do
+  # Set property that can be queried with Chef search
+  node.default['prometheus_exporters']['postgres']['enabled'] = true
+
   options = "--web.listen-address '#{new_resource.web_listen_address}'"
   options += " --web.telemetry-path '#{new_resource.web_telemetry_path}'" if new_resource.web_telemetry_path
   options += " --log.level #{new_resource.log_level}" if new_resource.log_level

--- a/resources/redis.rb
+++ b/resources/redis.rb
@@ -22,6 +22,9 @@ property :namespace, String, default: 'redis'
 property :user, String, default: 'root'
 
 action :install do
+  # Set property that can be queried with Chef search
+  node.default['prometheus_exporters']['redis']['enabled'] = true
+
   options = "-web.listen-address #{new_resource.web_listen_address}"
   options += " -web.telemetry-path #{new_resource.web_telemetry_path}"
   options += " -log-format #{new_resource.log_format}"
@@ -143,7 +146,6 @@ action :enable do
 end
 
 action :start do
-  action_install
   service "redis_exporter_#{new_resource.name}" do
     action :start
   end

--- a/resources/snmp.rb
+++ b/resources/snmp.rb
@@ -16,6 +16,9 @@ property :config_file, String, default: '/etc/snmp_exporter/snmp.yaml'
 property :custom_options, String
 
 action :install do
+  # Set property that can be queried with Chef search
+  node.default['prometheus_exporters']['snmp']['enabled'] = true
+
   options = "--web.listen-address=#{new_resource.web_listen_address}"
   options += " --log.level=#{new_resource.log_level}"
   options += " --log.format=#{new_resource.log_format}"

--- a/resources/wmi.rb
+++ b/resources/wmi.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: prometheus_exporters
+# Resource:: snmp
+#
+# Copyright 2017, Evil Martians
+#
+# All rights reserved - Do Not Redistribute
+#
+
+resource_name :wmi_exporter
+
+property :version, String
+property :enabled_collectors, String, default: 'cpu,cs,logical_disk,net,os,service,system'
+property :listen_address, String, default: '0.0.0.0'
+property :listen_port, String, default: '9128'
+property :metrics_path, String, default: '/metrics'
+
+action :install do
+  params = "/Enabled_Collectors:#{new_resource.enabled_collectors}"
+  params += " /ListenAddress:#{new_resource.listen_address}"
+  params += " /ListenPort:#{new_resource.listen_port}"
+  params += " /MetricsPath:#{new_resource.metrics_path}"
+
+  chocolatey_package 'prometheus-wmi-exporter.install' do
+    action :install
+    version new_resource.version
+    options "--params '\"#{params}\"'"
+  end
+end
+
+action :upgrade do
+  params = "/Enabled_Collectors:#{new_resource.enabled_collectors}"
+  params += " /ListenAddress:#{new_resource.listen_address}"
+  params += " /ListenPort:#{new_resource.listen_port}"
+  params += " /MetricsPath:#{new_resource.metrics_path}"
+
+  chocolatey_package 'prometheus-wmi-exporter.install' do
+    action :upgrade
+    version new_resource.version
+    options params
+  end
+end
+
+action :uninstall do
+  chocolatey_package 'prometheus-wmi-exporter.install' do
+    action :uninstall
+  end
+end

--- a/resources/wmi.rb
+++ b/resources/wmi.rb
@@ -43,6 +43,6 @@ end
 
 action :uninstall do
   chocolatey_package 'prometheus-wmi-exporter.install' do
-    action :uninstall
+    action :remove
   end
 end

--- a/templates/default/initscript.erb
+++ b/templates/default/initscript.erb
@@ -22,7 +22,7 @@ USER=root
 <% end -%>
 <% if @env && @env.kind_of?(Hash) -%>
   <% @env.each do |k, v| -%>
-    export <%= k %>=<%= v %>
+    export <%= k %>='<%= v %>'
   <% end -%>
 <% end -%>
 

--- a/test/cookbooks/testrig/recipes/default.rb
+++ b/test/cookbooks/testrig/recipes/default.rb
@@ -77,3 +77,12 @@ postgres_exporter 'chef' do
 
   action %i[install enable start]
 end
+
+blackbox_exporter 'main' do
+  web_listen_address '0.0.0.0:9115'
+  config_file "/opt/blackbox_exporter-#{node['prometheus_exporters']['blackbox']['version']}.linux-amd64/blackbox.yml"
+  timeout_offset '0.5'
+  log_level 'info'
+
+  action %i[install enable start]
+end

--- a/test/cookbooks/testrig/recipes/default.rb
+++ b/test/cookbooks/testrig/recipes/default.rb
@@ -1,3 +1,21 @@
+directory '/etc/mysqld' do
+  action :create
+end
+
+file '/etc/mysqld/my.cnf' do
+  content 'user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+'
+  action :create
+end
+user 'mysql' do
+  comment 'Mock Mysql user'
+  system true
+end
 user 'prometheus' do
   comment 'Prometheus user'
   system true
@@ -11,6 +29,14 @@ end
 user 'opscode-pgsql' do
   comment 'Mock Chef PostgreSQL user'
   system true
+end
+
+mysqld_exporter 'main' do
+  data_source_name '/'
+  config_my_cnf '/etc/mysqld/my.cnf'
+  user 'mysql'
+
+  action %i[install enable start]
 end
 
 node_exporter 'first' do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,6 +1,17 @@
 os_name = os.name
 os_release = os.release.to_f
 
+# Mysqld exporter
+describe port(9104) do
+  it { should be_listening }
+  its('processes') { should cmp(/^mysqld_expo/) }
+end
+
+describe service('mysqld_exporter_main') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
 # Node exporter
 [9100, 9110].each do |node_exporter_port|
   describe port(node_exporter_port) do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -82,3 +82,16 @@ describe service('snmp_exporter_main') do
   it { should be_enabled } if os_name == 'ubuntu' and os_release > 14.04
   it { should be_running }
 end
+
+# Blackbox exporter
+
+describe port(9115) do
+  it { should be_listening }
+  its('processes') { should cmp(/^blackbox_expo/) }
+end
+
+describe service('blackbox_exporter_main') do
+  # Chef 14 resource service is broken on a first run on Ubuntu 14.
+  it { should be_enabled } if os_name == 'ubuntu' and os_release > 14.04
+  it { should be_running }
+end


### PR DESCRIPTION
- New exporters: mysql and wmi (for Windows).
- Each resource sets an attribute so a Prometheus server can discover the exporters using knife search.

The wmi_exporter is an odd one as it requires Windows. I have merged it but it may be better placed in a separate `prometheus_windows_exporters` cookbook.
