### PR TITLE
Update rabbit exporter configuration

### DIFF
--- a/attributes/rabbitmq.rb
+++ b/attributes/rabbitmq.rb
@@ -1,6 +1,6 @@
-default['prometheus_exporters']['rabbitmq']['version'] = '1.0.0-RC6.1'
+default['prometheus_exporters']['rabbitmq']['version'] = '1.0.0-RC7'
 default['prometheus_exporters']['rabbitmq']['url'] = "https://github.com/kbudde/rabbitmq_exporter/releases/download/v#{node['prometheus_exporters']['rabbitmq']['version']}/rabbitmq_exporter-#{node['prometheus_exporters']['rabbitmq']['version']}.linux-amd64.tar.gz"
-default['prometheus_exporters']['rabbitmq']['checksum'] = 'd4a60a924bda5235159cad61cf60ec2da209e2ff07f6ddf31745b38b2d4246b2'
+default['prometheus_exporters']['rabbitmq']['checksum'] = '2c7fee81884a94ac81cb1116094755de084e2e949c07a115394fecfc415487e9'
 
 default['prometheus_exporters']['rabbitmq']['exclude_metrics'] = ''
 default['prometheus_exporters']['rabbitmq']['include_queues'] = '.*'
@@ -8,7 +8,7 @@ default['prometheus_exporters']['rabbitmq']['include_vhost'] = '.*'
 default['prometheus_exporters']['rabbitmq']['log_level'] = 'info'
 default['prometheus_exporters']['rabbitmq']['max_queues'] = 0
 default['prometheus_exporters']['rabbitmq']['output_format'] = 'TTY'
-default['prometheus_exporters']['rabbitmq']['publish_addr'] = '127.0.0.1'
+default['prometheus_exporters']['rabbitmq']['publish_addr'] = ''
 default['prometheus_exporters']['rabbitmq']['publish_port'] = 9419
 default['prometheus_exporters']['rabbitmq']['rabbit_capabilities'] = 'bert,no_sort'
 default['prometheus_exporters']['rabbitmq']['rabbit_exporters'] = 'exchange,node,overview,queue'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'surrender@evilmartians.com'
 license          'Apache-2.0'
 description      'Installs / configures Prometheus exporters'
 
-version          '0.16.0'
+version          '0.16.1'
 
 chef_version '>= 12.11', '< 16.0'
 


### PR DESCRIPTION
- Upgrade rabbitmq exporter version - includes some bug fixes and supports configuration via config file
- Change default value of `publish_addr` - currently set to 127.0.0.1 which accepts only traffic from localhost and can't get all incoming traffic.