### PR TITLE
update depends chef_version < 17.0

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -40,3 +40,13 @@ suites:
       prometheus_exporters:
         node:
           collectors_disabled: ["wifi"]
+  - name: chef-16
+    run_list:
+      - recipe[testrig]
+    provisioner:
+      product_name: chef
+      product_version: 16
+    attributes:
+      prometheus_exporters:
+        node:
+          collectors_disabled: ["wifi"]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -95,3 +95,12 @@ suites:
       prometheus_exporters:
         node:
           collectors_disabled: ["wifi"]
+  - name: chef-16
+    run_list:
+      - recipe[testrig]
+    driver:
+      chef_version: 16
+    attributes:
+      prometheus_exporters:
+        node:
+          collectors_disabled: ["wifi"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ env:
   global:
   - KITCHEN_YAML=.kitchen.yml
   matrix:
+  - INSTANCE=chef-16-ubuntu-1804
+  - INSTANCE=chef-16-ubuntu-1604
+  - INSTANCE=chef-16-fedora-31
+  - INSTANCE=chef-16-fedora-30
+  - INSTANCE=chef-16-centos-7
+  - INSTANCE=chef-16-debian-10
+  - INSTANCE=chef-16-debian-9
+  - INSTANCE=chef-16-debian-8
+  - INSTANCE=chef-16-amazonlinux-2
+  - INSTANCE=chef-16-amazonlinux
   - INSTANCE=chef-15-ubuntu-1804
   - INSTANCE=chef-15-ubuntu-1604
   - INSTANCE=chef-15-fedora-31

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs / configures Prometheus exporters'
 
 version          '0.16.3'
 
-chef_version '>= 12.11', '< 16.0'
+chef_version '>= 12.11', '< 17.0'
 
 supports 'amazon'
 supports 'centos', '>= 6.9'


### PR DESCRIPTION
Hi,
I've add test for chef-16 to support.

It hasn't changed much from 15, so it's probably okay. I ran one test.

```
$ kitchen test chef-16-ubuntu-1804

...

> Test Summary: 70 successful, 0 failures, 0 skipped
```
