### PR TITLE
Update node_exporter collectors list

### DIFF
--- a/resources/node.rb
+++ b/resources/node.rb
@@ -11,6 +11,7 @@ COLLECTOR_LIST = %w(
   arp
   bcache
   bonding
+  btrfs
   buddyinfo
   conntrack
   cpu
@@ -39,18 +40,24 @@ COLLECTOR_LIST = %w(
   nfsd
   ntp
   perf
+  powersupplyclass
   pressure
   processes
   qdisc
+  rapl
   runit
+  schedstat
   sockstat
+  softnet
   stat
   supervisord
   systemd
   tcpstat
   textfile
+  thermal_zone
   time
   timex
+  udp_queues
   uname
   vmstat
   wifi


### PR DESCRIPTION
According to node_exporter [repository](https://github.com/prometheus/node_exporter/tree/master/collector) here we have some new collectors (for linux) which is not in the cookbook list.
Also when I'm roll out the cookbook with `collectors_enabled %w(cpu)` and all the rest of collectors as explicit list in `collectors_disabled` I am seeing this in the metrics output:
```
# HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
# TYPE node_scrape_collector_duration_seconds gauge
node_scrape_collector_duration_seconds{collector="btrfs"} 6.4413e-05
node_scrape_collector_duration_seconds{collector="cpu"} 0.000463053
node_scrape_collector_duration_seconds{collector="powersupplyclass"} 0.0059021
node_scrape_collector_duration_seconds{collector="rapl"} 4.6683e-05
node_scrape_collector_duration_seconds{collector="schedstat"} 0.000170298
node_scrape_collector_duration_seconds{collector="softnet"} 0.000227115
node_scrape_collector_duration_seconds{collector="thermal_zone"} 0.000316828
node_scrape_collector_duration_seconds{collector="udp_queues"} 0.00017145
```