### PR TITLE
fix process_exporter 'procnames' attribute

### DIFF
--- a/resources/process.rb
+++ b/resources/process.rb
@@ -26,7 +26,7 @@ action :install do
   options += ' -debug=true' if new_resource.debug
   options += " -namemapping='#{new_resource.namemapping}'" if new_resource.namemapping
   options += " -procfs=#{new_resource.procfs}" if new_resource.procfs
-  options += " -procnames='#{new_resource.procnames}'" if new_resource.procnames
+  options += " -procnames=#{new_resource.procnames}" if new_resource.procnames
   options += ' -recheck' if new_resource.recheck
   options += " #{new_resource.custom_options}" if new_resource.custom_options
 


### PR DESCRIPTION
**Problem**: `process_exporter` treats whole `procnames` string as process name if quotes used:
```
process_exporter[9948]: 2020/09/14 11:15:26 Reading metrics from /proc for procnames: ['node_exporter other_process']
```
**Fix**:
* remove quotes from `procnames` option.
  Result:
  ```
  process_exporter[10990]: 2020/09/14 11:15:26 Reading metrics from /proc for procnames: [node_exporter other_process]
  ```