### PR TITLE
update depends chef_version < 18.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        chef-version: [14, 15, 16]
+        chef-version: [14, 15, 16, 17]
         os:
           - amazonlinux
           - amazonlinux-2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint cookbook
         run: bundle exec foodcritic --context --epic-fail any .
       - name: Run rspec tests
-        run: bundle exec rspec -fd test/cookbooks/testrig/spec/chefspec.r
+        run: bundle exec rspec -fd test/cookbooks/testrig/spec/chefspec.rb
 
   kitchen-test:
     runs-on: ubuntu-20.04

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -50,3 +50,13 @@ suites:
       prometheus_exporters:
         node:
           collectors_disabled: ["wifi"]
+  - name: chef-17
+    run_list:
+      - recipe[testrig]
+    provisioner:
+      product_name: chef
+      product_version: 16
+    attributes:
+      prometheus_exporters:
+        node:
+          collectors_disabled: ["wifi"]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -104,3 +104,12 @@ suites:
       prometheus_exporters:
         node:
           collectors_disabled: ["wifi"]
+  - name: chef-17
+    run_list:
+      - recipe[testrig]
+    driver:
+      chef_version: 17
+    attributes:
+      prometheus_exporters:
+        node:
+          collectors_disabled: ["wifi"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,17 @@ env:
   global:
   - KITCHEN_YAML=.kitchen.yml
   matrix:
-  - INSTANCE=chef-16-ubuntu-1804
+  - INSTANCE=chef-17-ubuntu-1804
+  - INSTANCE=chef-17-ubuntu-1604
+  - INSTANCE=chef-17-fedora-31
+  - INSTANCE=chef-17-fedora-30
+  - INSTANCE=chef-17-centos-7
+  - INSTANCE=chef-17-debian-10
+  - INSTANCE=chef-17-debian-9
+  - INSTANCE=chef-17-debian-8
+  - INSTANCE=chef-17-amazonlinux-2
+  - INSTANCE=chef-17-amazonlinux
+  - INSTANCE=chef-17-ubuntu-1804
   - INSTANCE=chef-16-ubuntu-1604
   - INSTANCE=chef-16-fedora-31
   - INSTANCE=chef-16-fedora-30

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs / configures Prometheus exporters'
 
 version          '0.17.3'
 
-chef_version '>= 12.11', '< 17.0'
+chef_version '>= 12.11', '< 18.0'
 
 supports 'amazon'
 supports 'centos', '>= 6.9'


### PR DESCRIPTION
Hi,
I've add test for chef-17 to support.

It hasn't changed much from 16, so it's probably okay. I ran one test.

```
$ kitchen test chef-17-ubuntu-1804

...

> Test Summary: 74 successful, 0 failures, 0 skipped
```