### PR TITLE
redis: add ping-on-connect parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ end
 * `connection_timeout` Timeout for connection to Redis instance (default: "15s")
 * `debug` Enable or disable debug output. (default: false)
 * `include_system_metrics` Whether to include system metrics like e.g. redis\_total\_system\_memory\_bytes
+* `ping_on_connect` Whether to ping the redis instance after connecting and record the duration as a metric. (default: false)
 * `is_tile38` Whether to scrape Tile38 specific metrics.
 * `log_format` In what format should logs be shown. (default: "txt")
 * `namespace` Namespace for the metrics. (default: "redis")

--- a/resources/redis.rb
+++ b/resources/redis.rb
@@ -16,6 +16,7 @@ property :config_command, String
 property :connection_timeout, String
 property :debug, [true, false], default: false
 property :include_system_metrics, [true, false], default: false
+property :ping_on_connect, [true, false], default: false
 property :is_tile38, [true, false], default: false
 property :log_format, String, default: 'txt'
 property :namespace, String, default: 'redis'
@@ -45,6 +46,7 @@ action :install do
   options += " -connection-timeout '#{new_resource.connection_timeout}'" if new_resource.connection_timeout
   options += ' -debug' if new_resource.debug
   options += ' -include-system-metrics' if new_resource.include_system_metrics
+  options += ' -ping-on-connect' if new_resource.ping_on_connect
   options += ' -is-tile38' if new_resource.is_tile38
   options += " -redis.addr '#{new_resource.redis_addr}'" if new_resource.redis_addr
   options += ' -redis-only-metrics' if new_resource.redis_only_metrics


### PR DESCRIPTION
## Add ping-on-connect parameter  for redis-exporter
This will add feature to enable `ping-on-connect` for redis-exporter.
Description from [redis-exporter](https://github.com/oliver006/redis_exporter/) documentation:
> ping-on-connect: Whether to ping the redis instance after connecting and record the duration as a metric, defaults to false.

Changes:
* `ping_on_connect ` Attribute added for redis resource
* Readme extended